### PR TITLE
Development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This repository contains `dnsmonitor.sh`, a POSIX shell script fragment for monitoring active DNS connections on OpenWrt routers. It parses `/proc/net/nf_conntrack` (Linux netfilter connection tracking) to detect DNS traffic on ports 53 (Do53) and 853 (DoT).
+
+### Linting
+
+- **shellcheck**: Run `shellcheck dnsmonitor.sh` to lint. The script is a code fragment (not a complete standalone script), so SC2154 warnings about unassigned variables are expected — those variables are defined in the full upstream script context.
+- **Syntax check**: Run `sh -n dnsmonitor.sh` for a quick syntax validation.
+
+### Testing
+
+There is no automated test suite. To test the grep/awk pipelines, create mock `/proc/net/nf_conntrack` data and pipe it through the script's patterns. The real `/proc/net/nf_conntrack` is not available in this cloud VM environment (no active netfilter conntrack).
+
+### Runtime caveat
+
+The script requires Linux kernel netfilter connection tracking (`/proc/net/nf_conntrack`). This file is not present in the cloud agent container, so the script cannot be run as a daemon here. Functional testing must use mock data or be performed on an actual OpenWrt/Linux router.


### PR DESCRIPTION
Add `AGENTS.md` to document the development environment setup and testing procedures for `dnsmonitor.sh`.

---
<p><a href="https://cursor.com/agents/bc-79f90856-ca62-4dc8-bfea-46a86af8ec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79f90856-ca62-4dc8-bfea-46a86af8ec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change; no runtime code paths or behavior are modified.
> 
> **Overview**
> Adds `AGENTS.md` documenting Cursor Cloud development guidance for `dnsmonitor.sh`, including how to run `shellcheck`/`sh -n`, how to do basic pipeline testing with mocked `/proc/net/nf_conntrack` input, and a note that `/proc/net/nf_conntrack` isn’t available in the agent container so daemon-style runtime testing must be done on a real router.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42ebd2bc3ba2adb8c0ef2c2caea14ff4de1920e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->